### PR TITLE
Make error messages from multiple inheritance compatibility check more accurate

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1605,6 +1605,16 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     if name in base2.names and base2 not in base.mro:
                         self.check_compatibility(name, base, base2, typ)
 
+    def determine_type_of_class_member(self, sym: SymbolTableNode) -> Optional[Type]:
+        if sym.type is not None:
+            return sym.type
+        if isinstance(sym.node, FuncBase):
+            return self.function_type(sym.node)
+        if isinstance(sym.node, TypeInfo):
+            # nested class
+            return type_object_type(sym.node, self.named_type)
+        return None
+
     def check_compatibility(self, name: str, base1: TypeInfo,
                             base2: TypeInfo, ctx: Context) -> None:
         """Check if attribute name in base1 is compatible with base2 in multiple inheritance.
@@ -1618,19 +1628,21 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return
         first = base1[name]
         second = base2[name]
-        first_type = first.type
-        if first_type is None and isinstance(first.node, FuncBase):
-            first_type = self.function_type(first.node)
-        second_type = second.type
-        if second_type is None and isinstance(second.node, FuncBase):
-            second_type = self.function_type(second.node)
+        first_type = self.determine_type_of_class_member(first)
+        second_type = self.determine_type_of_class_member(second)
+
         # TODO: What if some classes are generic?
         if (isinstance(first_type, FunctionLike) and
                 isinstance(second_type, FunctionLike)):
-            # Method override
-            first_sig = bind_self(first_type)
-            second_sig = bind_self(second_type)
-            ok = is_subtype(first_sig, second_sig, ignore_pos_arg_names=True)
+            if first_type.is_type_obj() and second_type.is_type_obj():
+                # For class objects only check the subtype relationship of the classes,
+                # since we allow incompatible overrides of '__init__'/'__new__'
+                ok = is_subtype(left=fill_typevars(first_type.type_object()),
+                                right=fill_typevars(second_type.type_object()))
+            else:
+                first_sig = bind_self(first_type)
+                second_sig = bind_self(second_type)
+                ok = is_subtype(first_sig, second_sig, ignore_pos_arg_names=True)
         elif first_type and second_type:
             ok = is_equivalent(first_type, second_type)
         else:

--- a/test-data/unit/check-multiple-inheritance.test
+++ b/test-data/unit/check-multiple-inheritance.test
@@ -240,3 +240,241 @@ def dec(f: Callable[..., T]) -> Callable[..., T]:
 [out]
 main:3: error: Cannot determine type of 'f' in base class 'B'
 main:3: error: Cannot determine type of 'f' in base class 'C'
+
+[case testMultipleInheritance_NestedClassesWithSameName]
+class Mixin1:
+    class Meta:
+        pass
+class Mixin2:
+    class Meta:
+        pass
+class A(Mixin1, Mixin2):
+    pass
+[out]
+main:7: error: Definition of "Meta" in base class "Mixin1" is incompatible with definition in base class "Mixin2"
+
+[case testMultipleInheritance_NestedClassesWithSameNameCustomMetaclass]
+class Metaclass(type):
+    pass
+class Mixin1:
+    class Meta(metaclass=Metaclass):
+        pass
+class Mixin2:
+    class Meta(metaclass=Metaclass):
+        pass
+class A(Mixin1, Mixin2):
+    pass
+[out]
+main:9: error: Definition of "Meta" in base class "Mixin1" is incompatible with definition in base class "Mixin2"
+
+[case testMultipleInheritance_NestedClassesWithSameNameOverloadedNew]
+from mixins import Mixin1, Mixin2
+class A(Mixin1, Mixin2):
+    pass
+[file mixins.py]
+class Mixin1:
+    class Meta:
+        pass
+class Mixin2:
+    class Meta:
+        pass
+[file mixins.pyi]
+from typing import overload, Any, Mapping, Dict
+class Mixin1:
+    class Meta:
+        @overload
+        def __new__(cls, *args, **kwargs: None) -> Mixin1.Meta:
+            pass
+        @overload
+        def __new__(cls, *args, **kwargs: Dict[str, Any]) -> Mixin1.Meta:
+            pass
+class Mixin2:
+    class Meta:
+        pass
+[builtins fixtures/dict.pyi]
+[out]
+main:2: error: Definition of "Meta" in base class "Mixin1" is incompatible with definition in base class "Mixin2"
+
+[case testMultipleInheritance_NestedClassAndAttrHaveSameName]
+class Mixin1:
+    class Nested1:
+        pass
+class Mixin2:
+    Nested1: str
+class A(Mixin1, Mixin2):
+    pass
+[out]
+main:6: error: Definition of "Nested1" in base class "Mixin1" is incompatible with definition in base class "Mixin2"
+
+[case testMultipleInheritance_NestedClassAndFunctionHaveSameName]
+class Mixin1:
+    class Nested1:
+        pass
+class Mixin2:
+    def Nested1(self) -> str:
+        pass
+class A(Mixin1, Mixin2):
+    pass
+[out]
+main:7: error: Definition of "Nested1" in base class "Mixin1" is incompatible with definition in base class "Mixin2"
+
+[case testMultipleInheritance_NestedClassAndRefToOtherClass]
+class Outer:
+    pass
+class Mixin1:
+    class Nested1:
+        pass
+class Mixin2:
+    Nested1 = Outer
+class A(Mixin2, Mixin1):
+    pass
+[out]
+main:8: error: Definition of "Nested1" in base class "Mixin2" is incompatible with definition in base class "Mixin1"
+
+[case testMultipleInheritance_ReferenceToSubclassesFromSameMRO]
+class A:
+    def __init__(self, arg: str) -> None:
+        pass
+class B(A):
+    pass
+class Base1:
+    NestedVar = A
+class Base2:
+    NestedVar = B
+class Combo(Base2, Base1): ...
+[out]
+
+[case testMultipleInheritance_ReferenceToSubclassesFromSameMROCustomMetaclass]
+class Metaclass(type):
+    pass
+class A(metaclass=Metaclass):
+    pass
+class B(A):
+    pass
+class Base1:
+    NestedVar = A
+class Base2:
+    NestedVar = B
+class Combo(Base2, Base1): ...
+[out]
+
+[case testMultipleInheritance_ReferenceToSubclassesFromSameMROOverloadedNew]
+from mixins import A, B
+class Base1:
+    NestedVar = A
+class Base2:
+    NestedVar = B
+class Combo(Base2, Base1): ...
+[file mixins.py]
+class A:
+    pass
+class B(A):
+    pass
+[file mixins.pyi]
+from typing import overload, Dict, Any
+class A:
+    @overload
+    def __new__(cls, *args, **kwargs: None) -> A:
+        pass
+    @overload
+    def __new__(cls, *args, **kwargs: Dict[str, Any]) -> A:
+        pass
+class B:
+    pass
+[builtins fixtures/dict.pyi]
+[out]
+main:6: error: Definition of "NestedVar" in base class "Base2" is incompatible with definition in base class "Base1"
+
+[case testMultipleInheritance_ReferenceToGenericClasses]
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Generic1(Generic[T]):
+    pass
+class Generic2(Generic[T]):
+    pass
+class Base1:
+    Nested = Generic1
+class Base2:
+    Nested = Generic2
+class A(Base1, Base2):
+    pass
+[out]
+main:11: error: Definition of "Nested" in base class "Base1" is incompatible with definition in base class "Base2"
+
+[case testMultipleInheritance_RefersToNamedTuples]
+from typing import NamedTuple
+class NamedTuple1:
+    attr1: int
+class NamedTuple2:
+    attr2: int
+class Base1:
+    Nested = NamedTuple1
+class Base2:
+    Nested = NamedTuple2
+class A(Base1, Base2):
+    pass
+[out]
+main:10: error: Definition of "Nested" in base class "Base1" is incompatible with definition in base class "Base2"
+
+[case testMultipleInheritance_NestedVariableRefersToSuperlassUnderSubclass]
+class A:
+    def __init__(self, arg: str) -> None:
+        pass
+class B(A):
+    pass
+class Base1:
+    NestedVar = B
+class Base2:
+    NestedVar = A
+class Combo(Base2, Base1): ...
+[out]
+main:10: error: Definition of "NestedVar" in base class "Base2" is incompatible with definition in base class "Base1"
+
+[case testNestedVariableRefersToSubclassOfAnotherNestedClass]
+class Mixin1:
+    class Meta:
+        pass
+class Outer(Mixin1.Meta):
+    pass
+class Mixin2:
+    NestedVar = Outer
+class Combo(Mixin2, Mixin1): ...
+[out]
+
+[case testNestedVariableRefersToCompletelyDifferentClasses]
+class A:
+    pass
+class B:
+    pass
+class Base1:
+    NestedVar = A
+class Base2:
+    NestedVar = B
+class Combo(Base2, Base1): ...
+[out]
+main:9: error: Definition of "NestedVar" in base class "Base2" is incompatible with definition in base class "Base1"
+
+[case testDoNotFailIfBothNestedClassesInheritFromAny]
+from typing import Any
+class Mixin1:
+    class Meta(Any):
+        pass
+class Mixin2:
+    class Meta(Any):
+        pass
+class A(Mixin1, Mixin2):
+    pass
+[out]
+
+[case testDoNotFailIfOneOfNestedClassesIsOuterInheritedFromAny]
+from typing import Any
+class Outer(Any):
+    pass
+class Mixin1:
+    Meta = Outer
+class Mixin2:
+    class Meta(Any):
+        pass
+class A(Mixin1, Mixin2):
+    pass
+[out]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/2871.

1. In discussion with @ilevkivskyi in Gitter, he suggested to just remove error, if there are two nested classes in a multiple inheritance with the same name
```
class Mixin1:
    class Meta:
        pass
class Mixin2:
    class Meta:
        pass
class A(Mixin1, Mixin2):
    pass
```
2. Better error message for cases with nested class and non-class for obvious cases. @ilevkivskyi also suggested to compare `__init__`  method signature of nested class and signature of function, if they have the same name, I'm going to work on it after review / in separate PR. 